### PR TITLE
docs/15-api-endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,63 @@ src/
 
 ## Auth Endpoints
 
-### TODO: auth endpoints here
+### Testing Authentication
+
+---
+
+### Sign In & Get Session
+
+**Step 1: Sign In**
+
+1. Navigate to the login page:
+
+   ```
+   http://localhost:3000/login
+   ```
+
+2. Click **"Sign in"** and complete login using your `@dlsu.edu.ph` email
+
+**Step 2: Test in Browser Console**
+
+After successful sign-in, open **DevTools Console** (F12) and run:
+
+```javascript
+// Get current session
+fetch('/api/auth/get-session', { credentials: 'include' })
+  .then((r) => r.json())
+  .then(console.log);
+```
+
+**Expected Response:**
+
+```json
+{
+  "session": {
+    "id": "cm3abc123...",
+    "userId": "cm3xyz789...",
+    "expiresAt": "2025-11-11T05:17:54.229Z",
+    "token": "...",
+    "ipAddress": "::1",
+    "userAgent": "Mozilla/5.0...",
+    "createdAt": "2025-11-04T10:30:00.000Z",
+    "updatedAt": "2025-11-04T10:30:00.000Z"
+  },
+  "user": {
+    "id": "cm3xyz789...",
+    "name": "Juan Dela Cruz",
+    "email": "juan_delacruz@dlsu.edu.ph",
+    "emailVerified": true,
+    "image": "https://lh3.googleusercontent.com/...",
+    "createdAt": "2025-11-04T10:30:00.000Z",
+    "updatedAt": "2025-11-04T10:30:00.000Z"
+  }
+}
+```
+
+---
+
+> [!IMPORTANT]
+> OAuth authentication must be completed in a browser. The Google OAuth flow requires user interaction and cannot be automated via API calls.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # archerbytes
 
 This project was bootstrapped with **create-lscs-next-app**.
@@ -59,7 +58,7 @@ Recommended libraries for future installs:
 - **Data Fetching**: [TanStack Query](https://tanstack.com/query/latest)
 - **State Management**: [Zustand](https://zustand-bear.github.io/zustand/)
 - **Forms**: [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/)
-- **Authentication**: [NextAuth.js](https://next-auth.js.org/)
+- **Authentication**: [Better Auth](https://www.better-auth.com/)
 - **Animations**: [Framer Motion](https://www.framer.com/motion/)
 - **Testing**: [Vitest](https://vitest.dev/) + [Cypress](https://www.cypress.io/)
 - **Icons**: [React Icons](https://react-icons.github.io/react-icons/)
@@ -128,7 +127,690 @@ src/
 
 ---
 
-## 6. 🤝 Code Contribution Guide
+## 6. 🔌 API Documentation
+
+> [!NOTE]
+> All curl examples use `curl.exe` which works in both PowerShell and Command Prompt on Windows. On Unix-based systems (macOS/Linux), use `curl` instead.
+
+## Auth Endpoints
+
+### TODO: auth endpoints here
+
+---
+
+## Comment Endpoints
+
+### POST `/api/comments`
+
+- creates a new comment or reply to an existing comment
+
+- `request`:
+
+```bash
+curl.exe -X POST http://localhost:3000/api/comments ^
+  -H "Content-Type: application/json" ^
+  -d "{\"userId\":\"user_123\",\"articleId\":\"article_456\",\"content\":\"This is a comment\",\"replyTo\":null}"
+```
+
+- **Request Body Fields:**
+  - `userId` (string, required): The user ID creating the comment
+  - `articleId` (string, required): The article ID being commented on
+  - `content` (string, required): The comment content
+  - `replyTo` (number, optional): Parent comment ID if this is a reply
+
+- `response`:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "userId": "user_123",
+    "articleId": "article_456",
+    "replyTo": null,
+    "content": "This is a comment",
+    "createdAt": "2025-11-01T12:00:00.000Z",
+    "updatedAt": "2025-11-01T12:00:00.000Z"
+  }
+}
+```
+
+```json
+{
+  "error": "Parent comment does not exist."
+}
+```
+
+```json
+{
+  "error": "Can only reply to parent comments."
+}
+```
+
+### GET `/api/comments`
+
+- returns all parent comments for a specific article
+
+- `request`:
+
+```bash
+curl.exe -X GET "http://localhost:3000/api/comments?articleId=article_456"
+```
+
+- **Query Parameters:**
+  - `articleId` (string, required): The article ID to fetch comments for
+
+- `response`:
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "userId": "user_123",
+      "articleId": "article_456",
+      "replyTo": null,
+      "content": "This is a comment",
+      "createdAt": "2025-11-01T12:00:00.000Z",
+      "updatedAt": "2025-11-01T12:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "userId": "user_456",
+      "articleId": "article_456",
+      "replyTo": null,
+      "content": "Amazing Article!",
+      "createdAt": "2025-11-02T14:51:03.666Z",
+      "updatedAt": "2025-11-02T14:51:03.666Z"
+    }
+  ]
+}
+```
+
+```json
+{
+  "error": "Article ID is required"
+}
+```
+
+### GET `/api/comments/[id]`
+
+- returns a specific comment by ID
+
+- `request`:
+
+```bash
+curl.exe -X GET http://localhost:3000/api/comments/1
+```
+
+- `response`:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "userId": "user_123",
+    "articleId": "article_456",
+    "replyTo": null,
+    "content": "This is a comment",
+    "createdAt": "2025-11-02T14:23:26.358Z",
+    "updatedAt": "2025-11-02T14:23:26.358Z"
+  }
+}
+```
+
+```json
+{
+  "error": "Comment not found"
+}
+```
+
+### PATCH `/api/comments/[id]`
+
+- updates a comment
+
+- `request`:
+
+```bash
+curl.exe -X PATCH http://localhost:3000/api/comments/1 ^
+  -H "Content-Type: application/json" ^
+  -d "{\"userId\":\"user_123\",\"content\":\"Updated comment content\"}"
+```
+
+- **Request Body Fields:**
+  - `userId` (string, required): The user ID that created the comment
+  - `content` (string, required): The new comment content
+
+- `response`:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "userId": "user_123",
+    "articleId": "article_456",
+    "content": "Updated comment content",
+    "replyTo": null,
+    "createdAt": "2025-11-01T12:00:00.000Z",
+    "updatedAt": "2025-11-01T12:00:00.000Z"
+  }
+}
+```
+
+```json
+{
+  "error": "userId is required"
+}
+```
+
+```json
+{
+  "error": "Comment not found or you are not the owner"
+}
+```
+
+### DELETE `/api/comments/[id]`
+
+- deletes a comment
+
+- `request`:
+
+```bash
+curl.exe -X DELETE http://localhost:3000/api/comments/1 ^
+  -H "Content-Type: application/json" ^
+  -d "{\"userId\":\"user_123\"}"
+```
+
+- **Request Body Fields:**
+  - `userId` (string, required): The user ID that created the comment
+
+- `response`:
+
+```json
+{
+  "message": "Comment deleted successfully",
+  "data": {
+    "id": 1,
+    "userId": "user_123",
+    "articleId": "article_456",
+    "replyTo": null,
+    "content": "This is a comment",
+    "createdAt": "2025-11-01T12:00:00.000Z",
+    "updatedAt": "2025-11-01T12:00:00.000Z"
+  }
+}
+```
+
+```json
+{
+  "error": "Comment not found or you are not the owner"
+}
+```
+
+### GET `/api/comments/[id]/replies`
+
+- returns all replies to a specific parent comment
+
+- `request`:
+
+```bash
+curl.exe -X GET http://localhost:3000/api/comments/1/replies
+```
+
+- `response`:
+
+```json
+{
+  "data": [
+    {
+      "id": 2,
+      "userId": "user_456",
+      "articleId": "article_456",
+      "replyTo": 1,
+      "content": "This is a reply",
+      "createdAt": "2025-11-01T12:30:00.000Z",
+      "updatedAt": "2025-11-01T12:30:00.000Z"
+    }
+  ]
+}
+```
+
+```json
+{
+  "error": "Parent comment not found"
+}
+```
+
+---
+
+## Comment Reaction Endpoints
+
+### POST `/api/comment-reactions`
+
+- creates or updates a reaction to a comment
+
+- `request`:
+
+```bash
+curl.exe -X POST http://localhost:3000/api/comment-reactions ^
+  -H "Content-Type: application/json" ^
+  -d "{\"userId\":\"user_123\",\"commentId\":1,\"reactionType\":\"like\"}"
+```
+
+- **Request Body Fields:**
+  - `userId` (string, required): The user ID creating the reaction
+  - `commentId` (number, required): The comment ID being reacted to
+  - `reactionType` (string, required): Must be one of: "like", "heart", "care", "haha", "wow", "sad", "angry"
+
+- `response`:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "userId": "user_123",
+    "commentId": 1,
+    "reactionType": "like",
+    "createdAt": "2025-11-01T12:00:00.000Z"
+  }
+}
+```
+
+```json
+{
+  "error": "You have already reacted to this comment"
+}
+```
+
+```json
+{
+  "error": "Comment not found"
+}
+```
+
+```json
+{
+  "error": "Validation failed",
+  "details": [
+    {
+      "code": "invalid_value",
+      "values": ["like", "heart", "care", "haha", "wow", "sad", "angry"],
+      "path": ["reactionType"],
+      "message": "Invalid option: expected one of \"like\"|\"heart\"|\"care\"|\"haha\"|\"wow\"|\"sad\"|\"angry\""
+    }
+  ]
+}
+```
+
+### GET `/api/comment-reactions`
+
+- returns all reactions for a specific comment, or a specific user's reaction
+
+- `request` (all reactions):
+
+```bash
+curl.exe -X GET "http://localhost:3000/api/comment-reactions?commentId=1"
+```
+
+- `request` (specific user's reactions):
+
+```bash
+curl.exe -X GET "http://localhost:3000/api/comment-reactions?commentId=1&userId=user_123"
+```
+
+- **Query Parameters:**
+  - `commentId` (number, required): The comment ID to fetch reactions for
+  - `userId` (string, optional): Filter reactions by specific user
+
+- `response` (all reactions):
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "userId": "user_123",
+      "commentId": 1,
+      "reactionType": "like",
+      "createdAt": "2025-11-01T12:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "userId": "user_456",
+      "commentId": 1,
+      "reactionType": "heart",
+      "createdAt": "2025-11-01T12:15:00.000Z"
+    }
+  ]
+}
+```
+
+- `response` (user's reactions):
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "userId": "user_123",
+      "commentId": 1,
+      "reactionType": "like",
+      "createdAt": "2025-11-01T12:00:00.000Z"
+    }
+  ]
+}
+```
+
+```json
+{
+  "error": "commentId query parameter is required"
+}
+```
+
+```json
+{
+  "error": "commentId must be a valid number"
+}
+```
+
+### PATCH `/api/comment-reactions`
+
+- updates a user's reaction type on a comment
+
+- `request`:
+
+```bash
+curl.exe -X PATCH http://localhost:3000/api/comment-reactions ^
+  -H "Content-Type: application/json" ^
+  -d "{\"userId\":\"user_123\",\"commentId\":1,\"reactionType\":\"heart\"}"
+```
+
+- **Request Body Fields:**
+  - `userId` (string, required): The user ID who created the reaction
+  - `commentId` (number, required): The comment ID
+  - `reactionType` (string, required): New reaction type (one of: "like", "heart", "care", "haha", "wow", "sad", "angry")
+
+- `response`:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "userId": "user_123",
+    "commentId": 1,
+    "reactionType": "heart",
+    "createdAt": "2025-11-01T12:00:00.000Z"
+  }
+}
+```
+
+```json
+{
+  "error": "Reaction not found or you are not authorized to update it"
+}
+```
+
+```json
+{
+  "error": "Validation failed",
+  "details": [
+    {
+      "code": "invalid_enum_value",
+      "options": ["like", "heart", "care", "haha", "wow", "sad", "angry"],
+      "path": ["reactionType"],
+      "message": "Invalid enum value. Expected 'like' | 'heart' | 'care' | 'haha' | 'wow' | 'sad' | 'angry', received 'invalid'"
+    }
+  ]
+}
+```
+
+### DELETE `/api/comment-reactions`
+
+- deletes a reaction from a comment
+
+- `request`:
+
+```bash
+curl.exe -X DELETE http://localhost:3000/api/comment-reactions ^
+  -H "Content-Type: application/json" ^
+  -d "{\"userId\":\"user_123\",\"commentId\":1}"
+```
+
+- **Request Body Fields:**
+  - `userId` (string, required): The user ID who created the reaction
+  - `commentId` (number, required): The comment ID
+
+- `response`:
+
+```json
+{
+  "message": "Reaction deleted successfully",
+  "data": {
+    "id": 1,
+    "userId": "user_123",
+    "commentId": 1,
+    "reactionType": "like",
+    "createdAt": "2025-11-01T12:00:00.000Z"
+  }
+}
+```
+
+```json
+{
+  "error": "Reaction not found or you are not authorized to delete it"
+}
+```
+
+---
+
+## Article Reaction Endpoints
+
+### POST `/api/article-reactions`
+
+- creates a reaction to an article
+
+- `request`:
+
+```bash
+curl.exe -X POST http://localhost:3000/api/article-reactions ^
+  -H "Content-Type: application/json" ^
+  -d "{\"userId\":\"user_123\",\"articleId\":\"article_456\",\"reactionType\":\"like\"}"
+```
+
+- **Request Body Fields:**
+  - `userId` (string, required): The user ID creating the reaction
+  - `articleId` (string, required): The article ID being reacted to
+  - `reactionType` (string, required): Must be one of: "like", "heart", "care", "haha", "wow", "sad", "angry"
+
+- `response`:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "userId": "user_123",
+    "articleId": "article_456",
+    "reactionType": "like",
+    "createdAt": "2025-11-01T12:00:00.000Z"
+  }
+}
+```
+
+```json
+{
+  "error": "You have already reacted to this article"
+}
+```
+
+```json
+{
+  "error": "Validation failed",
+  "details": [
+    {
+      "code": "invalid_enum_value",
+      "options": ["like", "heart", "care", "haha", "wow", "sad", "angry"],
+      "path": ["reactionType"],
+      "message": "Invalid enum value. Expected 'like' | 'heart' | 'care' | 'haha' | 'wow' | 'sad' | 'angry', received 'invalid'"
+    }
+  ]
+}
+```
+
+### GET `/api/article-reactions`
+
+- returns all reactions for a specific article, or a specific user's reaction
+
+- `request` (all reactions):
+
+```bash
+curl.exe -X GET "http://localhost:3000/api/article-reactions?articleId=article_456"
+```
+
+- `request` (specific user's reactions):
+
+```bash
+curl.exe -X GET "http://localhost:3000/api/article-reactions?articleId=article_456&userId=user_123"
+```
+
+- **Query Parameters:**
+  - `articleId` (string, required): The article ID to fetch reactions for
+  - `userId` (string, optional): Filter reactions by specific user
+
+- `response` (all reactions):
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "userId": "user_123",
+      "articleId": "article_456",
+      "reactionType": "like",
+      "createdAt": "2025-11-01T12:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "userId": "user_789",
+      "articleId": "article_456",
+      "reactionType": "heart",
+      "createdAt": "2025-11-01T12:30:00.000Z"
+    }
+  ]
+}
+```
+
+- `response` (user's reactions):
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "userId": "user_123",
+      "articleId": "article_456",
+      "reactionType": "like",
+      "createdAt": "2025-11-01T12:00:00.000Z"
+    }
+  ]
+}
+```
+
+```json
+{
+  "error": "articleId query parameter is required"
+}
+```
+
+### PATCH `/api/article-reactions`
+
+- updates a user's reaction type on an article
+
+- `request`:
+
+```bash
+curl.exe -X PATCH http://localhost:3000/api/article-reactions ^
+  -H "Content-Type: application/json" ^
+  -d "{\"userId\":\"user_123\",\"articleId\":\"article_456\",\"reactionType\":\"heart\"}"
+```
+
+- **Request Body Fields:**
+  - `userId` (string, required): The user ID who created the reaction
+  - `articleId` (string, required): The article ID
+  - `reactionType` (string, required): New reaction type (one of: "like", "heart", "care", "haha", "wow", "sad", "angry")
+
+- `response`:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "userId": "user_123",
+    "articleId": "article_456",
+    "reactionType": "heart",
+    "createdAt": "2025-11-01T12:00:00.000Z"
+  }
+}
+```
+
+```json
+{
+  "error": "Reaction not found or you are not authorized to update it"
+}
+```
+
+```json
+{
+  "error": "Validation failed",
+  "details": [
+    {
+      "code": "invalid_enum_value",
+      "options": ["like", "heart", "care", "haha", "wow", "sad", "angry"],
+      "path": ["reactionType"],
+      "message": "Invalid enum value. Expected 'like' | 'heart' | 'care' | 'haha' | 'wow' | 'sad' | 'angry', received 'invalid'"
+    }
+  ]
+}
+```
+
+### DELETE `/api/article-reactions`
+
+- deletes a reaction from an article
+
+- `request`:
+
+```bash
+curl.exe -X DELETE http://localhost:3000/api/article-reactions ^
+  -H "Content-Type: application/json" ^
+  -d "{\"userId\":\"user_123\",\"articleId\":\"article_456\"}"
+```
+
+- **Request Body Fields:**
+  - `userId` (string, required): The user ID who created the reaction
+  - `articleId` (string, required): The article ID
+
+- `response`:
+
+```json
+{
+  "message": "Reaction deleted successfully",
+  "data": {
+    "id": 1,
+    "userId": "user_123",
+    "articleId": "article_456",
+    "reactionType": "like",
+    "createdAt": "2025-11-01T12:00:00.000Z"
+  }
+}
+```
+
+```json
+{
+  "error": "Reaction not found or you are not authorized to delete it"
+}
+```
+
+---
+
+## 7. 🤝 Code Contribution Guide
 
 ### Branch Model
 

--- a/src/app/api/comment-reactions/route.ts
+++ b/src/app/api/comment-reactions/route.ts
@@ -36,9 +36,8 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ data: reactions });
     }
 
-    const totalReactions =
-      await ReactionService.getTotalReactionsByCommentId(commentId);
-    return NextResponse.json({ data: totalReactions });
+    const reactions = await ReactionService.getReactionsByCommentId(commentId);
+    return NextResponse.json({ data: reactions });
   } catch (error) {
     console.error('Error fetching comment reactions:', error);
     return NextResponse.json(
@@ -77,6 +76,7 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       );
     }
+
     const errorMessage = error instanceof Error ? error.message : '';
     const errorCause =
       error instanceof Error && 'cause' in error ? error.cause : null;

--- a/src/app/api/comments/[id]/replies/route.ts
+++ b/src/app/api/comments/[id]/replies/route.ts
@@ -13,6 +13,14 @@ export async function GET(
       return NextResponse.json({ error: 'Invalid ID format' }, { status: 400 });
     }
 
+    const parentComment = await CommentService.getById(numericId);
+    if (!parentComment) {
+      return NextResponse.json(
+        { error: 'Parent comment not found' },
+        { status: 404 },
+      );
+    }
+
     const replies = await CommentService.getReplies(numericId);
 
     return NextResponse.json({ data: replies }, { status: 200 });

--- a/src/app/api/comments/[id]/route.ts
+++ b/src/app/api/comments/[id]/route.ts
@@ -5,10 +5,11 @@ import { ZodError } from 'zod';
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const id = Number(params.id);
+    const { id: idParam } = await params;
+    const id = Number(idParam);
     if (isNaN(id)) {
       return NextResponse.json(
         { error: 'Invalid comment ID' },
@@ -34,10 +35,11 @@ export async function GET(
 
 export async function PATCH(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const id = Number(params.id);
+    const { id: idParam } = await params;
+    const id = Number(idParam);
     if (isNaN(id)) {
       return NextResponse.json(
         { error: 'Invalid comment ID' },
@@ -84,10 +86,11 @@ export async function PATCH(
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const id = Number(params.id);
+    const { id: idParam } = await params;
+    const id = Number(idParam);
     if (isNaN(id)) {
       return NextResponse.json(
         { error: 'Invalid comment ID' },

--- a/src/features/reactions/services/service.ts
+++ b/src/features/reactions/services/service.ts
@@ -1,6 +1,6 @@
 import { db } from '@/config/database';
 import { articleReactions, commentReactions } from '@/lib/db/reactions.entity';
-import { eq, and, sql } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
 import type {
   CreateArticleReactionInput,
   DeleteArticleReactionInput,
@@ -27,6 +27,19 @@ export async function createArticleReaction(data: CreateArticleReactionInput) {
   }
 }
 
+export async function getReactionsByArticleId(articleId: string) {
+  try {
+    return await db
+      .select()
+      .from(articleReactions)
+      .where(eq(articleReactions.articleId, articleId))
+      .orderBy(articleReactions.createdAt);
+  } catch (error) {
+    console.error('Error fetching reactions by article:', error);
+    throw error;
+  }
+}
+
 export async function getReactionsByArticleIdAndUserId(
   articleId: string,
   userId: string,
@@ -44,22 +57,6 @@ export async function getReactionsByArticleIdAndUserId(
       .orderBy(articleReactions.createdAt);
   } catch (error) {
     console.error('Error fetching reactions by article and user:', error);
-    throw error;
-  }
-}
-
-export async function getTotalReactionsByArticleId(articleId: string) {
-  try {
-    return await db
-      .select({
-        reactionType: articleReactions.reactionType,
-        count: sql<number>`cast(count(*) as integer)`,
-      })
-      .from(articleReactions)
-      .where(eq(articleReactions.articleId, articleId))
-      .groupBy(articleReactions.reactionType);
-  } catch (error) {
-    console.error('Error fetching total reactions for article:', error);
     throw error;
   }
 }
@@ -118,6 +115,19 @@ export async function createCommentReaction(data: CreateCommentReactionInput) {
   }
 }
 
+export async function getReactionsByCommentId(commentId: number) {
+  try {
+    return await db
+      .select()
+      .from(commentReactions)
+      .where(eq(commentReactions.commentId, commentId))
+      .orderBy(commentReactions.createdAt);
+  } catch (error) {
+    console.error('Error fetching reactions by comment:', error);
+    throw error;
+  }
+}
+
 export async function getReactionsByCommentIdAndUserId(
   commentId: number,
   userId: string,
@@ -135,22 +145,6 @@ export async function getReactionsByCommentIdAndUserId(
       .orderBy(commentReactions.createdAt);
   } catch (error) {
     console.error('Error fetching reactions by comment and user:', error);
-    throw error;
-  }
-}
-
-export async function getTotalReactionsByCommentId(commentId: number) {
-  try {
-    return await db
-      .select({
-        reactionType: commentReactions.reactionType,
-        count: sql<number>`cast(count(*) as integer)`,
-      })
-      .from(commentReactions)
-      .where(eq(commentReactions.commentId, commentId))
-      .groupBy(commentReactions.reactionType);
-  } catch (error) {
-    console.error('Error fetching total reactions for comment:', error);
     throw error;
   }
 }
@@ -194,13 +188,13 @@ export async function deleteCommentReaction(data: DeleteCommentReactionInput) {
 
 export const ReactionService = {
   createArticleReaction,
+  getReactionsByArticleId,
   getReactionsByArticleIdAndUserId,
-  getTotalReactionsByArticleId,
   updateArticleReaction,
   deleteArticleReaction,
   createCommentReaction,
+  getReactionsByCommentId,
   getReactionsByCommentIdAndUserId,
-  getTotalReactionsByCommentId,
   updateCommentReaction,
   deleteCommentReaction,
 };


### PR DESCRIPTION
### Summary

Refactored reaction endpoints to return complete reaction details instead of aggregated counts. Updated API route handlers to include full reaction objects (id, userId, commentId/articleId, reactionType, createdAt) para mas madali sa frontend. Added duplicate reaction detection.  Added API documentation 

### Linked Issues

closes \#15

### Type of Change

- [x] feat: New feature
- [x] fix: Bug fix
- [x] docs: Documentation update
- [ ] chore/refactor: Maintenance or code restructure

### Notes for Reviewers

- i did not add the auth endpoints documentation yet kasi di ko pa sure pano siya iaadd since nung tinest ko yung authentication, inintegrate ko lang yung auth sa sign in button
