### PR TITLE
Feat/29 add cms webhook

### DIFF
--- a/drizzle/0009_tricky_sabra.sql
+++ b/drizzle/0009_tricky_sabra.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "comments" ALTER COLUMN "article_id" SET DATA TYPE integer;--> statement-breakpoint
+ALTER TABLE "article_reactions" ALTER COLUMN "article_id" SET DATA TYPE integer;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "occupation" text;--> statement-breakpoint
+ALTER TABLE "article_categories" ADD COLUMN "cms_category_id" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "articles" ADD COLUMN "cms_article_id" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "articles" ADD COLUMN "deleted_at" timestamp;--> statement-breakpoint
+ALTER TABLE "comments" ADD CONSTRAINT "comments_article_id_articles_id_fk" FOREIGN KEY ("article_id") REFERENCES "public"."articles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "article_reactions" ADD CONSTRAINT "article_reactions_article_id_articles_id_fk" FOREIGN KEY ("article_id") REFERENCES "public"."articles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "article_categories_cms_category_id_idx" ON "article_categories" USING btree ("cms_category_id");--> statement-breakpoint
+CREATE INDEX "articles_cms_article_id_idx" ON "articles" USING btree ("cms_article_id");--> statement-breakpoint
+CREATE INDEX "articles_deleted_at_idx" ON "articles" USING btree ("deleted_at");--> statement-breakpoint
+ALTER TABLE "article_categories" ADD CONSTRAINT "article_categories_cms_category_id_unique" UNIQUE("cms_category_id");--> statement-breakpoint
+ALTER TABLE "articles" ADD CONSTRAINT "articles_cms_article_id_unique" UNIQUE("cms_article_id");

--- a/drizzle/0010_flowery_tyger_tiger.sql
+++ b/drizzle/0010_flowery_tyger_tiger.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "article_categories" ALTER COLUMN "cms_category_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "articles" ALTER COLUMN "cms_article_id" DROP NOT NULL;

--- a/drizzle/0011_magical_silver_surfer.sql
+++ b/drizzle/0011_magical_silver_surfer.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "article_categories" ADD COLUMN "deleted_at" timestamp;--> statement-breakpoint
+CREATE INDEX "article_categories_deleted_at_idx" ON "article_categories" USING btree ("deleted_at");

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,926 @@
+{
+  "id": "81281de2-06a1-4814-8f05-b00f407c0f70",
+  "prevId": "dba70351-57be-41eb-92f3-c9e8d342f383",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_article_id_articles_id_fk": {
+          "name": "comments_article_id_articles_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_reply_to_comments_id_fk": {
+          "name": "comments_reply_to_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "reply_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.article_reactions": {
+      "name": "article_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "reaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "article_reactions_article_id_articles_id_fk": {
+          "name": "article_reactions_article_id_articles_id_fk",
+          "tableFrom": "article_reactions",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_article": {
+          "name": "unique_user_article",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "article_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_reactions": {
+      "name": "comment_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "reaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comment_reactions_comment_id_comments_id_fk": {
+          "name": "comment_reactions_comment_id_comments_id_fk",
+          "tableFrom": "comment_reactions",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_comment": {
+          "name": "unique_user_comment",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "comment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.article_categories": {
+      "name": "article_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cms_category_id": {
+          "name": "cms_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "article_categories_cms_category_id_idx": {
+          "name": "article_categories_cms_category_id_idx",
+          "columns": [
+            {
+              "expression": "cms_category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "article_categories_cms_category_id_unique": {
+          "name": "article_categories_cms_category_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cms_category_id"
+          ]
+        },
+        "article_categories_slug_unique": {
+          "name": "article_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cms_article_id": {
+          "name": "cms_article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured_image_url": {
+          "name": "featured_image_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_image_url": {
+          "name": "meta_image_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "article_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "articles_cms_article_id_idx": {
+          "name": "articles_cms_article_id_idx",
+          "columns": [
+            {
+              "expression": "cms_article_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_status_idx": {
+          "name": "articles_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_category_id_idx": {
+          "name": "articles_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_status_published_at_idx": {
+          "name": "articles_status_published_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_deleted_at_idx": {
+          "name": "articles_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "articles_category_id_article_categories_id_fk": {
+          "name": "articles_category_id_article_categories_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "article_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "articles_user_id_user_id_fk": {
+          "name": "articles_user_id_user_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "articles_cms_article_id_unique": {
+          "name": "articles_cms_article_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cms_article_id"
+          ]
+        },
+        "articles_slug_unique": {
+          "name": "articles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.reaction_type": {
+      "name": "reaction_type",
+      "schema": "public",
+      "values": [
+        "like",
+        "heart",
+        "care",
+        "haha",
+        "wow",
+        "sad",
+        "angry"
+      ]
+    },
+    "public.article_status": {
+      "name": "article_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,926 @@
+{
+  "id": "121e808e-316e-4284-b8bd-ddac5a01c257",
+  "prevId": "81281de2-06a1-4814-8f05-b00f407c0f70",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_article_id_articles_id_fk": {
+          "name": "comments_article_id_articles_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_reply_to_comments_id_fk": {
+          "name": "comments_reply_to_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "reply_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.article_reactions": {
+      "name": "article_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "reaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "article_reactions_article_id_articles_id_fk": {
+          "name": "article_reactions_article_id_articles_id_fk",
+          "tableFrom": "article_reactions",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_article": {
+          "name": "unique_user_article",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "article_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_reactions": {
+      "name": "comment_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "reaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comment_reactions_comment_id_comments_id_fk": {
+          "name": "comment_reactions_comment_id_comments_id_fk",
+          "tableFrom": "comment_reactions",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_comment": {
+          "name": "unique_user_comment",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "comment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.article_categories": {
+      "name": "article_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cms_category_id": {
+          "name": "cms_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "article_categories_cms_category_id_idx": {
+          "name": "article_categories_cms_category_id_idx",
+          "columns": [
+            {
+              "expression": "cms_category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "article_categories_cms_category_id_unique": {
+          "name": "article_categories_cms_category_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cms_category_id"
+          ]
+        },
+        "article_categories_slug_unique": {
+          "name": "article_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cms_article_id": {
+          "name": "cms_article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured_image_url": {
+          "name": "featured_image_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_image_url": {
+          "name": "meta_image_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "article_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "articles_cms_article_id_idx": {
+          "name": "articles_cms_article_id_idx",
+          "columns": [
+            {
+              "expression": "cms_article_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_status_idx": {
+          "name": "articles_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_category_id_idx": {
+          "name": "articles_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_status_published_at_idx": {
+          "name": "articles_status_published_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_deleted_at_idx": {
+          "name": "articles_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "articles_category_id_article_categories_id_fk": {
+          "name": "articles_category_id_article_categories_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "article_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "articles_user_id_user_id_fk": {
+          "name": "articles_user_id_user_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "articles_cms_article_id_unique": {
+          "name": "articles_cms_article_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cms_article_id"
+          ]
+        },
+        "articles_slug_unique": {
+          "name": "articles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.reaction_type": {
+      "name": "reaction_type",
+      "schema": "public",
+      "values": [
+        "like",
+        "heart",
+        "care",
+        "haha",
+        "wow",
+        "sad",
+        "angry"
+      ]
+    },
+    "public.article_status": {
+      "name": "article_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,947 @@
+{
+  "id": "e8408178-41ec-4f7a-8b47-dd3c073e028c",
+  "prevId": "121e808e-316e-4284-b8bd-ddac5a01c257",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_article_id_articles_id_fk": {
+          "name": "comments_article_id_articles_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_reply_to_comments_id_fk": {
+          "name": "comments_reply_to_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "reply_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.article_reactions": {
+      "name": "article_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "reaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "article_reactions_article_id_articles_id_fk": {
+          "name": "article_reactions_article_id_articles_id_fk",
+          "tableFrom": "article_reactions",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_article": {
+          "name": "unique_user_article",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "article_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_reactions": {
+      "name": "comment_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "reaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comment_reactions_comment_id_comments_id_fk": {
+          "name": "comment_reactions_comment_id_comments_id_fk",
+          "tableFrom": "comment_reactions",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_comment": {
+          "name": "unique_user_comment",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "comment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.article_categories": {
+      "name": "article_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cms_category_id": {
+          "name": "cms_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "article_categories_cms_category_id_idx": {
+          "name": "article_categories_cms_category_id_idx",
+          "columns": [
+            {
+              "expression": "cms_category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "article_categories_deleted_at_idx": {
+          "name": "article_categories_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "article_categories_cms_category_id_unique": {
+          "name": "article_categories_cms_category_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cms_category_id"
+          ]
+        },
+        "article_categories_slug_unique": {
+          "name": "article_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cms_article_id": {
+          "name": "cms_article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured_image_url": {
+          "name": "featured_image_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_image_url": {
+          "name": "meta_image_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "article_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "articles_cms_article_id_idx": {
+          "name": "articles_cms_article_id_idx",
+          "columns": [
+            {
+              "expression": "cms_article_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_status_idx": {
+          "name": "articles_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_category_id_idx": {
+          "name": "articles_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_status_published_at_idx": {
+          "name": "articles_status_published_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_deleted_at_idx": {
+          "name": "articles_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "articles_category_id_article_categories_id_fk": {
+          "name": "articles_category_id_article_categories_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "article_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "articles_user_id_user_id_fk": {
+          "name": "articles_user_id_user_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "articles_cms_article_id_unique": {
+          "name": "articles_cms_article_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cms_article_id"
+          ]
+        },
+        "articles_slug_unique": {
+          "name": "articles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.reaction_type": {
+      "name": "reaction_type",
+      "schema": "public",
+      "values": [
+        "like",
+        "heart",
+        "care",
+        "haha",
+        "wow",
+        "sad",
+        "angry"
+      ]
+    },
+    "public.article_status": {
+      "name": "article_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778224381894,
       "tag": "0010_flowery_tyger_tiger",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1778225998428,
+      "tag": "0011_magical_silver_surfer",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,20 @@
       "when": 1777550000000,
       "tag": "0008_add_user_occupation",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1778224311517,
+      "tag": "0009_tricky_sabra",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1778224381894,
+      "tag": "0010_flowery_tyger_tiger",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__tests__/unit/webhooks/article-handler.test.ts
+++ b/src/__tests__/unit/webhooks/article-handler.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { handleArticleEvent } from '@/lib/webhooks/handlers/article.handler';
+import { CMSSyncService } from '@/features/article/services/cms-sync.service';
+import type { ArticleWebhookPayload } from '@/lib/webhooks/types';
+
+vi.mock('@/lib/cms-api', () => ({
+  cmsApiClient: {
+    fetchArticle: vi.fn(),
+    fetchCategory: vi.fn(),
+  },
+}));
+
+vi.mock('@/config/database', () => ({
+  db: {
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    onConflictDoUpdate: vi.fn().mockReturnThis(),
+    target: undefined,
+    set: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue([{ id: 1, slug: 'test-article' }]),
+    limit: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+describe('Article Event Handler', () => {
+  const mockArticlePayload: ArticleWebhookPayload = {
+    event: 'article',
+    action: 'created',
+    articleId: 'test-article-slug',
+    timestamp: new Date().toISOString(),
+    cms: 'payload-cms',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Article creation event', () => {
+    it('should handle article.created event', async () => {
+      const syncSpy = vi.spyOn(CMSSyncService, 'syncArticle').mockResolvedValue({
+        id: 1,
+        slug: 'test-article',
+      });
+
+      const payload: ArticleWebhookPayload = {
+        ...mockArticlePayload,
+        action: 'created',
+      };
+
+      await handleArticleEvent(payload);
+
+      expect(syncSpy).toHaveBeenCalledWith('test-article-slug');
+    });
+
+    it('should handle article.updated event', async () => {
+      const syncSpy = vi.spyOn(CMSSyncService, 'syncArticle').mockResolvedValue({
+        id: 1,
+        slug: 'test-article',
+      });
+
+      const payload: ArticleWebhookPayload = {
+        ...mockArticlePayload,
+        action: 'updated',
+      };
+
+      await handleArticleEvent(payload);
+
+      expect(syncSpy).toHaveBeenCalledWith('test-article-slug');
+    });
+  });
+
+  describe('Article deletion event', () => {
+    it('should handle article.deleted event', async () => {
+      const deleteSpy = vi.spyOn(CMSSyncService, 'deleteArticle').mockResolvedValue();
+
+      const payload: ArticleWebhookPayload = {
+        ...mockArticlePayload,
+        action: 'deleted',
+      };
+
+      await handleArticleEvent(payload);
+
+      expect(deleteSpy).toHaveBeenCalledWith('test-article-slug');
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should throw error when sync fails', async () => {
+      vi.spyOn(CMSSyncService, 'syncArticle').mockRejectedValue(
+        new Error('CMS API error')
+      );
+
+      const payload: ArticleWebhookPayload = {
+        ...mockArticlePayload,
+        action: 'created',
+      };
+
+      await expect(handleArticleEvent(payload)).rejects.toThrow('CMS API error');
+    });
+
+    it('should log error details', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(CMSSyncService, 'syncArticle').mockRejectedValue(
+        new Error('Test error')
+      );
+
+      const payload: ArticleWebhookPayload = {
+        ...mockArticlePayload,
+        action: 'created',
+      };
+
+      try {
+        await handleArticleEvent(payload);
+      } catch {
+      }
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/unit/webhooks/auth-validation.test.ts
+++ b/src/__tests__/unit/webhooks/auth-validation.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { POST } from '@/app/api/webhooks/cms/route';
 import { NextRequest } from 'next/server';
 
+vi.mock('@/config/database', () => ({
+  db: {},
+}));
+
+vi.mock('@/lib/cms-api', () => ({
+  cmsApiClient: {},
+}));
+
 beforeEach(() => {
   process.env.WEBHOOK_SECRET = 'test-webhook-secret-123';
 });
@@ -34,7 +42,8 @@ describe('CMS Webhook Endpoint', () => {
   describe('Authentication', () => {
     it('should return 401 when Authorization header is missing', async () => {
       const req = createMockRequest({
-        event: 'article.created',
+        event: 'article',
+        action: 'created',
         articleId: '123',
         timestamp: new Date().toISOString(),
       });
@@ -50,7 +59,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should return 401 when Authorization header has invalid format', async () => {
       const req = createMockRequest(
         {
-          event: 'article.created',
+          event: 'article',
+          action: 'created',
           articleId: '123',
           timestamp: new Date().toISOString(),
         },
@@ -65,7 +75,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should return 401 when Bearer token is incorrect', async () => {
       const req = createMockRequest(
         {
-          event: 'article.created',
+          event: 'article',
+          action: 'created',
           articleId: '123',
           timestamp: new Date().toISOString(),
         },
@@ -80,7 +91,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should accept valid Bearer token', async () => {
       const req = createMockRequest(
         {
-          event: 'article.created',
+          event: 'article',
+          action: 'created',
           articleId: '123',
           timestamp: new Date().toISOString(),
         },
@@ -134,7 +146,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should return 400 when articleId is missing for article event', async () => {
       const req = createMockRequest(
         {
-          event: 'article.created',
+          event: 'article',
+          action: 'created',
           timestamp: new Date().toISOString(),
         },
         { authHeader: validAuthHeader }
@@ -148,7 +161,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should return 400 when timestamp is invalid', async () => {
       const req = createMockRequest(
         {
-          event: 'article.created',
+          event: 'article',
+          action: 'created',
           articleId: '123',
           timestamp: 'not-a-valid-timestamp',
         },
@@ -163,7 +177,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should return 400 for unsupported event type', async () => {
       const req = createMockRequest(
         {
-          event: 'unknown.event',
+          event: 'unknown',
+          action: 'created',
           articleId: '123',
           timestamp: new Date().toISOString(),
         },
@@ -182,7 +197,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should return 202 for valid article.created event', async () => {
       const req = createMockRequest(
         {
-          event: 'article.created',
+          event: 'article',
+          action: 'created',
           articleId: 'my-article-slug',
           timestamp: new Date().toISOString(),
         },
@@ -201,7 +217,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should return 202 for valid article.updated event', async () => {
       const req = createMockRequest(
         {
-          event: 'article.updated',
+          event: 'article',
+          action: 'updated',
           articleId: '456',
           timestamp: new Date().toISOString(),
         },
@@ -216,7 +233,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should return 202 for valid article.deleted event', async () => {
       const req = createMockRequest(
         {
-          event: 'article.deleted',
+          event: 'article',
+          action: 'deleted',
           articleId: '789',
           timestamp: new Date().toISOString(),
         },
@@ -231,7 +249,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should return 202 for valid category.created event', async () => {
       const req = createMockRequest(
         {
-          event: 'category.created',
+          event: 'category',
+          action: 'created',
           categoryId: 'tech-news',
           timestamp: new Date().toISOString(),
         },
@@ -248,7 +267,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should return 202 for valid category.updated event', async () => {
       const req = createMockRequest(
         {
-          event: 'category.updated',
+          event: 'category',
+          action: 'updated',
           categoryId: '100',
           timestamp: new Date().toISOString(),
         },
@@ -263,7 +283,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should return 202 for valid category.deleted event', async () => {
       const req = createMockRequest(
         {
-          event: 'category.deleted',
+          event: 'category',
+          action: 'deleted',
           categoryId: '200',
           timestamp: new Date().toISOString(),
         },
@@ -278,7 +299,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should include webhook ID for tracking', async () => {
       const req = createMockRequest(
         {
-          event: 'article.created',
+          event: 'article',
+          action: 'created',
           articleId: 'test-article',
           timestamp: new Date().toISOString(),
         },
@@ -294,7 +316,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should accept optional cms field', async () => {
       const req = createMockRequest(
         {
-          event: 'article.created',
+          event: 'article',
+          action: 'created',
           articleId: '123',
           timestamp: new Date().toISOString(),
           cms: 'payload-cms',
@@ -314,7 +337,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should handle numeric articleId as string', async () => {
       const req = createMockRequest(
         {
-          event: 'article.created',
+          event: 'article',
+          action: 'created',
           articleId: '12345',
           timestamp: new Date().toISOString(),
         },
@@ -329,7 +353,8 @@ describe('CMS Webhook Endpoint', () => {
     it('should reject empty articleId', async () => {
       const req = createMockRequest(
         {
-          event: 'article.created',
+          event: 'article',
+          action: 'created',
           articleId: '',
           timestamp: new Date().toISOString(),
         },
@@ -347,7 +372,8 @@ describe('CMS Webhook Endpoint', () => {
 
       const req = createMockRequest(
         {
-          event: 'article.created',
+          event: 'article',
+          action: 'created',
           articleId: '123',
           timestamp: futureDate.toISOString(),
         },

--- a/src/__tests__/unit/webhooks/auth-validation.test.ts
+++ b/src/__tests__/unit/webhooks/auth-validation.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { POST } from '@/app/api/webhooks/cms/route';
+import { NextRequest } from 'next/server';
+
+beforeEach(() => {
+  process.env.WEBHOOK_SECRET = 'test-webhook-secret-123';
+});
+
+afterEach(() => {
+  delete process.env.WEBHOOK_SECRET;
+  vi.clearAllMocks();
+});
+
+function createMockRequest(
+  body: unknown,
+  options?: {
+    authHeader?: string;
+  }
+): NextRequest {
+  const headers = new Headers();
+
+  if (options?.authHeader) {
+    headers.set('Authorization', options.authHeader);
+  }
+
+  return new NextRequest('http://localhost:3000/api/webhooks/cms', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe('CMS Webhook Endpoint', () => {
+  describe('Authentication', () => {
+    it('should return 401 when Authorization header is missing', async () => {
+      const req = createMockRequest({
+        event: 'article.created',
+        articleId: '123',
+        timestamp: new Date().toISOString(),
+      });
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.status).toBe('rejected');
+      expect(data.message).toContain('Authorization header');
+    });
+
+    it('should return 401 when Authorization header has invalid format', async () => {
+      const req = createMockRequest(
+        {
+          event: 'article.created',
+          articleId: '123',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: 'InvalidFormat token-here' }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should return 401 when Bearer token is incorrect', async () => {
+      const req = createMockRequest(
+        {
+          event: 'article.created',
+          articleId: '123',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: 'Bearer wrong-secret' }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should accept valid Bearer token', async () => {
+      const req = createMockRequest(
+        {
+          event: 'article.created',
+          articleId: '123',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: 'Bearer test-webhook-secret-123' }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).not.toBe(401);
+    });
+  });
+
+  describe('Payload Validation', () => {
+    const validAuthHeader = 'Bearer test-webhook-secret-123';
+
+    it('should return 400 when JSON is malformed', async () => {
+      const headers = new Headers();
+      headers.set('Authorization', validAuthHeader);
+
+      const req = new NextRequest('http://localhost:3000/api/webhooks/cms', {
+        method: 'POST',
+        headers,
+        body: 'not-valid-json{',
+      });
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.status).toBe('rejected');
+      expect(data.message).toContain('JSON');
+    });
+
+    it('should return 400 when event field is missing', async () => {
+      const req = createMockRequest(
+        {
+          articleId: '123',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.status).toBe('rejected');
+      expect(data.details).toBeDefined();
+    });
+
+    it('should return 400 when articleId is missing for article event', async () => {
+      const req = createMockRequest(
+        {
+          event: 'article.created',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 400 when timestamp is invalid', async () => {
+      const req = createMockRequest(
+        {
+          event: 'article.created',
+          articleId: '123',
+          timestamp: 'not-a-valid-timestamp',
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 400 for unsupported event type', async () => {
+      const req = createMockRequest(
+        {
+          event: 'unknown.event',
+          articleId: '123',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('Valid Payloads', () => {
+    const validAuthHeader = 'Bearer test-webhook-secret-123';
+
+    it('should return 202 for valid article.created event', async () => {
+      const req = createMockRequest(
+        {
+          event: 'article.created',
+          articleId: 'my-article-slug',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(202);
+      const data = await response.json();
+      expect(data.status).toBe('accepted');
+      expect(data.id).toBeDefined();
+      expect(data.timestamp).toBeDefined();
+    });
+
+    it('should return 202 for valid article.updated event', async () => {
+      const req = createMockRequest(
+        {
+          event: 'article.updated',
+          articleId: '456',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(202);
+    });
+
+    it('should return 202 for valid article.deleted event', async () => {
+      const req = createMockRequest(
+        {
+          event: 'article.deleted',
+          articleId: '789',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(202);
+    });
+
+    it('should return 202 for valid category.created event', async () => {
+      const req = createMockRequest(
+        {
+          event: 'category.created',
+          categoryId: 'tech-news',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(202);
+      const data = await response.json();
+      expect(data.status).toBe('accepted');
+    });
+
+    it('should return 202 for valid category.updated event', async () => {
+      const req = createMockRequest(
+        {
+          event: 'category.updated',
+          categoryId: '100',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(202);
+    });
+
+    it('should return 202 for valid category.deleted event', async () => {
+      const req = createMockRequest(
+        {
+          event: 'category.deleted',
+          categoryId: '200',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(202);
+    });
+
+    it('should include webhook ID for tracking', async () => {
+      const req = createMockRequest(
+        {
+          event: 'article.created',
+          articleId: 'test-article',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      const data = await response.json();
+      expect(data.id).toMatch(/^wh_\d+_/);
+    });
+
+    it('should accept optional cms field', async () => {
+      const req = createMockRequest(
+        {
+          event: 'article.created',
+          articleId: '123',
+          timestamp: new Date().toISOString(),
+          cms: 'payload-cms',
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(202);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    const validAuthHeader = 'Bearer test-webhook-secret-123';
+
+    it('should handle numeric articleId as string', async () => {
+      const req = createMockRequest(
+        {
+          event: 'article.created',
+          articleId: '12345',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(202);
+    });
+
+    it('should reject empty articleId', async () => {
+      const req = createMockRequest(
+        {
+          event: 'article.created',
+          articleId: '',
+          timestamp: new Date().toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should handle future timestamps', async () => {
+      const futureDate = new Date();
+      futureDate.setHours(futureDate.getHours() + 24);
+
+      const req = createMockRequest(
+        {
+          event: 'article.created',
+          articleId: '123',
+          timestamp: futureDate.toISOString(),
+        },
+        { authHeader: validAuthHeader }
+      );
+
+      const response = await POST(req);
+
+      expect(response.status).toBe(202);
+    });
+  });
+});

--- a/src/__tests__/unit/webhooks/category-handler.test.ts
+++ b/src/__tests__/unit/webhooks/category-handler.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { handleCategoryEvent } from '@/lib/webhooks/handlers/category.handler';
+import { CMSSyncService } from '@/features/article/services/cms-sync.service';
+import type { CategoryWebhookPayload } from '@/lib/webhooks/types';
+
+vi.mock('@/lib/cms-api', () => ({
+  cmsApiClient: {
+    fetchArticle: vi.fn(),
+    fetchCategory: vi.fn(),
+  },
+}));
+
+vi.mock('@/config/database', () => ({
+  db: {
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    onConflictDoUpdate: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue([{ id: 1, name: 'Tech News' }]),
+    limit: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+describe('Category Event Handler', () => {
+  const mockCategoryPayload: CategoryWebhookPayload = {
+    event: 'category',
+    action: 'created',
+    categoryId: 'tech-news',
+    timestamp: new Date().toISOString(),
+    cms: 'payload-cms',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('syncs categories on create and update', async () => {
+    const syncSpy = vi.spyOn(CMSSyncService, 'syncCategory').mockResolvedValue({
+      id: 1,
+      name: 'Tech News',
+    });
+
+    await handleCategoryEvent(mockCategoryPayload);
+    await handleCategoryEvent({ ...mockCategoryPayload, action: 'updated' });
+
+    expect(syncSpy).toHaveBeenCalledTimes(2);
+    expect(syncSpy).toHaveBeenNthCalledWith(1, 'tech-news');
+    expect(syncSpy).toHaveBeenNthCalledWith(2, 'tech-news');
+  });
+
+  it('ignores delete events', async () => {
+    const syncSpy = vi.spyOn(CMSSyncService, 'syncCategory').mockResolvedValue({
+      id: 1,
+      name: 'Tech News',
+    });
+
+    await handleCategoryEvent({ ...mockCategoryPayload, action: 'deleted' });
+
+    expect(syncSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/webhooks/cms-api.test.ts
+++ b/src/__tests__/unit/webhooks/cms-api.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cmsArticle = {
+  id: 1,
+  title: 'Test Article',
+  subtitle: 'Subtitle',
+  slug: 'test-article',
+  content: { root: { type: 'root', children: [] } },
+  category: { id: 2, name: 'News' },
+  createdAt: '2026-05-04T00:00:00.000Z',
+  updatedAt: '2026-05-04T00:00:00.000Z',
+};
+
+describe('CMS API client', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.CMS_API_URL = 'http://cms.test';
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+    delete process.env.CMS_API_URL;
+  });
+
+  it('fetches articles by slug using the list endpoint', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ docs: [cmsArticle] }),
+    });
+
+    const { cmsApiClient } = await import('@/lib/cms-api');
+    const article = await cmsApiClient.fetchArticle('test-article');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://cms.test/api/archerbytes-articles?where[slug][equals]=test-article&limit=1&depth=1',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(article.slug).toBe('test-article');
+  });
+
+  it('fetches articles by numeric id using the document endpoint', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ doc: cmsArticle }),
+    });
+
+    const { cmsApiClient } = await import('@/lib/cms-api');
+    const article = await cmsApiClient.fetchArticle(42);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://cms.test/api/archerbytes-articles/42?depth=1',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(article.id).toBe(1);
+  });
+});

--- a/src/app/api/webhooks/cms/route.ts
+++ b/src/app/api/webhooks/cms/route.ts
@@ -1,0 +1,38 @@
+
+import { NextRequest } from 'next/server';
+import { WebhookPayloadSchema } from '@/lib/webhooks/types';
+import { validateWebhookAuth } from '@/lib/webhooks/auth';
+import { accepted, badRequest, unauthorized } from '@/lib/webhooks/response';
+
+
+export async function POST(req: NextRequest) {
+  const authResult = validateWebhookAuth(req);
+  if (!authResult.valid) {
+    console.warn(`[Webhook] Unauthorized request: ${authResult.error}`);
+    return unauthorized(authResult.error);
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    const errorMsg = 'Failed to parse JSON body';
+    console.error(`[Webhook] ${errorMsg}:`, error);
+    return badRequest(errorMsg);
+  }
+
+  const validationResult = WebhookPayloadSchema.safeParse(payload);
+  if (!validationResult.success) {
+    const errorMsg = 'Invalid webhook payload schema';
+    console.warn(`[Webhook] ${errorMsg}:`, validationResult.error.issues);
+    return badRequest(errorMsg, validationResult.error.issues);
+  }
+
+  const webhookPayload = validationResult.data;
+  console.log(`[Webhook] Received ${webhookPayload.event} event for ID: ${
+    'articleId' in webhookPayload ? webhookPayload.articleId : webhookPayload.categoryId
+  } at ${webhookPayload.timestamp}`);
+
+
+  return accepted('Webhook received and queued for processing');
+}

--- a/src/app/api/webhooks/cms/route.ts
+++ b/src/app/api/webhooks/cms/route.ts
@@ -1,9 +1,9 @@
-
 import { NextRequest } from 'next/server';
 import { WebhookPayloadSchema } from '@/lib/webhooks/types';
 import { validateWebhookAuth } from '@/lib/webhooks/auth';
 import { accepted, badRequest, unauthorized } from '@/lib/webhooks/response';
-
+import { handleArticleEvent } from '@/lib/webhooks/handlers/article.handler';
+import { handleCategoryEvent } from '@/lib/webhooks/handlers/category.handler';
 
 export async function POST(req: NextRequest) {
   const authResult = validateWebhookAuth(req);
@@ -33,6 +33,17 @@ export async function POST(req: NextRequest) {
     'articleId' in webhookPayload ? webhookPayload.articleId : webhookPayload.categoryId
   } at ${webhookPayload.timestamp}`);
 
+  (async () => {
+    try {
+      if (webhookPayload.event === 'article') {
+        await handleArticleEvent(webhookPayload);
+      } else if (webhookPayload.event === 'category') {
+        await handleCategoryEvent(webhookPayload);
+      }
+    } catch (error) {
+      console.error(`[Webhook] Processing failed for ${webhookPayload.event}:`, error);
+    }
+  })();
 
   return accepted('Webhook received and queued for processing');
 }

--- a/src/features/article/services/cms-sync.service.ts
+++ b/src/features/article/services/cms-sync.service.ts
@@ -1,0 +1,114 @@
+import { db } from '@/config/database';
+import { articles, articleCategories } from '@/lib/db/schema';
+import { cmsApiClient } from '@/lib/cms-api';
+import { eq } from 'drizzle-orm';
+
+const SYSTEM_USER_ID = process.env.SYSTEM_USER_ID || 'system';
+
+export class CMSSyncService {
+  static async syncArticle(articleId: string | number): Promise<{ id: number; slug: string }> {
+    const cmsArticle = await cmsApiClient.fetchArticle(articleId);
+
+    const categoryId = typeof cmsArticle.category === 'number' 
+      ? cmsArticle.category 
+      : cmsArticle.category.id;
+
+    const existingCategory = await db
+      .select({ id: articleCategories.id })
+      .from(articleCategories)
+      .where(eq(articleCategories.id, categoryId))
+      .limit(1);
+
+    if (!existingCategory.length) {
+      await CMSSyncService.syncCategory(categoryId);
+    }
+
+    const articleData = {
+      title: cmsArticle.title,
+      subtitle: cmsArticle.subtitle,
+      slug: cmsArticle.slug,
+      content: JSON.stringify(cmsArticle.content),
+      categoryId,
+      userId: SYSTEM_USER_ID,
+      featuredImageUrl: this.extractImageUrl(cmsArticle.featuredImage),
+      tags: cmsArticle.tags || [],
+      metaTitle: cmsArticle.meta?.title || null,
+      metaDescription: cmsArticle.meta?.description || null,
+      metaImageUrl: this.extractImageUrl(cmsArticle.meta?.image),
+      status: (cmsArticle._status || 'draft') as 'draft' | 'published',
+      publishedAt: cmsArticle._status === 'published' 
+        ? new Date(cmsArticle.updatedAt) 
+        : null,
+      updatedAt: new Date(cmsArticle.updatedAt),
+    };
+
+    const result = await db
+      .insert(articles)
+      .values(articleData)
+      .onConflictDoUpdate({
+        target: articles.slug,
+        set: articleData,
+      })
+      .returning({ id: articles.id, slug: articles.slug });
+
+    if (!result.length) {
+      throw new Error(`Failed to sync article: ${articleId}`);
+    }
+
+    return result[0];
+  }
+
+  static async syncCategory(categoryId: string | number): Promise<{ id: number; name: string }> {
+    const cmsCategory = await cmsApiClient.fetchCategory(categoryId);
+
+    const categoryData = {
+      name: cmsCategory.name,
+      slug: this.slugify(cmsCategory.name),
+    };
+
+    const result = await db
+      .insert(articleCategories)
+      .values(categoryData)
+      .onConflictDoUpdate({
+        target: articleCategories.slug,
+        set: categoryData,
+      })
+      .returning({ id: articleCategories.id, name: articleCategories.name });
+
+    if (!result.length) {
+      throw new Error(`Failed to sync category: ${categoryId}`);
+    }
+
+    return result[0];
+  }
+
+  static async deleteArticle(articleId: string | number): Promise<void> {
+    const result = await db
+      .update(articles)
+      .set({ deletedAt: new Date() })
+      .where(eq(articles.slug, String(articleId)))
+      .returning({ id: articles.id });
+
+    if (!result.length) {
+      console.warn(`[CMS Sync] Article not found for deletion: ${articleId}`);
+    }
+  }
+
+  private static extractImageUrl(image: unknown): string | null {
+    if (!image) return null;
+    if (typeof image === 'string') return image;
+    if (typeof image === 'object' && image !== null && 'url' in image) {
+      return (image as { url: string }).url;
+    }
+    return null;
+  }
+
+  private static slugify(text: string): string {
+    return text
+      .toLowerCase()
+      .trim()
+      .replace(/[^\w\s-]/g, '')
+      .replace(/[\s_]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+}

--- a/src/features/article/services/cms-sync.service.ts
+++ b/src/features/article/services/cms-sync.service.ts
@@ -10,19 +10,30 @@ export class CMSSyncService {
     const cmsArticle = await cmsApiClient.fetchArticle(articleId);
     const cmsArticleId = typeof cmsArticle.id === 'string' ? parseInt(cmsArticle.id, 10) : cmsArticle.id;
 
-    const categoryId = typeof cmsArticle.category === 'number' 
+    const cmsCategoryId = typeof cmsArticle.category === 'number' 
       ? cmsArticle.category 
       : cmsArticle.category.id;
 
-    const existingCategory = await db
+    let existingCategory = await db
       .select({ id: articleCategories.id })
       .from(articleCategories)
-      .where(eq(articleCategories.id, categoryId))
+      .where(eq(articleCategories.cmsCategoryId, cmsCategoryId))
       .limit(1);
 
     if (!existingCategory.length) {
-      await CMSSyncService.syncCategory(categoryId);
+      await CMSSyncService.syncCategory(cmsCategoryId);
+      existingCategory = await db
+        .select({ id: articleCategories.id })
+        .from(articleCategories)
+        .where(eq(articleCategories.cmsCategoryId, cmsCategoryId))
+        .limit(1);
+      
+      if (!existingCategory.length) {
+        throw new Error(`Failed to sync article: category ${cmsCategoryId} not found after sync attempt`);
+      }
     }
+
+    const localCategoryId = existingCategory[0].id;
 
     const articleData = {
       cmsArticleId,
@@ -30,7 +41,7 @@ export class CMSSyncService {
       subtitle: cmsArticle.subtitle,
       slug: cmsArticle.slug,
       content: JSON.stringify(cmsArticle.content),
-      categoryId,
+      categoryId: localCategoryId,
       userId: SYSTEM_USER_ID,
       featuredImageUrl: this.extractImageUrl(cmsArticle.featuredImage),
       tags: cmsArticle.tags || [],

--- a/src/features/article/services/cms-sync.service.ts
+++ b/src/features/article/services/cms-sync.service.ts
@@ -8,6 +8,7 @@ const SYSTEM_USER_ID = process.env.SYSTEM_USER_ID || 'system';
 export class CMSSyncService {
   static async syncArticle(articleId: string | number): Promise<{ id: number; slug: string }> {
     const cmsArticle = await cmsApiClient.fetchArticle(articleId);
+    const cmsArticleId = typeof cmsArticle.id === 'string' ? parseInt(cmsArticle.id, 10) : cmsArticle.id;
 
     const categoryId = typeof cmsArticle.category === 'number' 
       ? cmsArticle.category 
@@ -24,6 +25,7 @@ export class CMSSyncService {
     }
 
     const articleData = {
+      cmsArticleId,
       title: cmsArticle.title,
       subtitle: cmsArticle.subtitle,
       slug: cmsArticle.slug,
@@ -46,7 +48,7 @@ export class CMSSyncService {
       .insert(articles)
       .values(articleData)
       .onConflictDoUpdate({
-        target: articles.slug,
+        target: articles.cmsArticleId,
         set: articleData,
       })
       .returning({ id: articles.id, slug: articles.slug });
@@ -60,8 +62,10 @@ export class CMSSyncService {
 
   static async syncCategory(categoryId: string | number): Promise<{ id: number; name: string }> {
     const cmsCategory = await cmsApiClient.fetchCategory(categoryId);
+    const cmsCategoryId = typeof cmsCategory.id === 'string' ? parseInt(cmsCategory.id, 10) : cmsCategory.id;
 
     const categoryData = {
+      cmsCategoryId,
       name: cmsCategory.name,
       slug: this.slugify(cmsCategory.name),
     };
@@ -70,7 +74,7 @@ export class CMSSyncService {
       .insert(articleCategories)
       .values(categoryData)
       .onConflictDoUpdate({
-        target: articleCategories.slug,
+        target: articleCategories.cmsCategoryId,
         set: categoryData,
       })
       .returning({ id: articleCategories.id, name: articleCategories.name });
@@ -83,10 +87,12 @@ export class CMSSyncService {
   }
 
   static async deleteArticle(articleId: string | number): Promise<void> {
+    const cmsArticleId = typeof articleId === 'string' ? parseInt(articleId, 10) : articleId;
+    
     const result = await db
       .update(articles)
       .set({ deletedAt: new Date() })
-      .where(eq(articles.slug, String(articleId)))
+      .where(eq(articles.cmsArticleId, cmsArticleId))
       .returning({ id: articles.id });
 
     if (!result.length) {

--- a/src/features/article/services/cms-sync.service.ts
+++ b/src/features/article/services/cms-sync.service.ts
@@ -100,6 +100,20 @@ export class CMSSyncService {
     }
   }
 
+  static async deleteCategory(categoryId: string | number): Promise<void> {
+    const cmsCategoryId = typeof categoryId === 'string' ? parseInt(categoryId, 10) : categoryId;
+    
+    const result = await db
+      .update(articleCategories)
+      .set({ deletedAt: new Date() })
+      .where(eq(articleCategories.cmsCategoryId, cmsCategoryId))
+      .returning({ id: articleCategories.id });
+
+    if (!result.length) {
+      console.warn(`[CMS Sync] Category not found for deletion: ${categoryId}`);
+    }
+  }
+
   private static extractImageUrl(image: unknown): string | null {
     if (!image) return null;
     if (typeof image === 'string') return image;

--- a/src/lib/cms-api.ts
+++ b/src/lib/cms-api.ts
@@ -37,6 +37,17 @@ class CMSApiClient {
     this.baseUrl = url.replace(/\/+$/, '');
   }
 
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    }
+    const cmsApiToken = process.env.CMS_API_TOKEN
+    if (cmsApiToken) {
+      headers['Authorization'] = `Bearer ${cmsApiToken}`
+    }
+    return headers
+  }
+
   async fetchArticle(articleId: string | number): Promise<CMSArticle> {
     const normalizedArticleId = String(articleId).trim();
     const url = this.isNumericId(normalizedArticleId)
@@ -45,7 +56,7 @@ class CMSApiClient {
 
     const response = await fetch(url, {
       method: 'GET',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this.getHeaders(),
       signal: AbortSignal.timeout(10000),
     });
 
@@ -67,7 +78,7 @@ class CMSApiClient {
 
     const response = await fetch(url, {
       method: 'GET',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this.getHeaders(),
       signal: AbortSignal.timeout(10000),
     });
 

--- a/src/lib/cms-api.ts
+++ b/src/lib/cms-api.ts
@@ -1,0 +1,106 @@
+export interface CMSArticle {
+  id: string | number;
+  title: string;
+  subtitle: string;
+  slug: string;
+  content: { root: { type: string; children: unknown[] }; [key: string]: unknown };
+  mdContent?: string | null;
+  featuredImage?: { id: number; url: string } | number | null;
+  category: { id: number; name: string } | number;
+  author?: { id: number; name: string } | number;
+  tags?: string[] | null;
+  meta?: {
+    title?: string | null;
+    image?: { id: number; url: string } | number | null;
+    description?: string | null;
+  };
+  _status?: 'draft' | 'published' | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CMSCategory {
+  id: string | number;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+class CMSApiClient {
+  private baseUrl: string;
+
+  constructor() {
+    const url = process.env.CMS_API_URL;
+    if (!url) {
+      throw new Error('CMS_API_URL environment variable is not configured');
+    }
+    this.baseUrl = url.replace(/\/+$/, '');
+  }
+
+  async fetchArticle(articleId: string | number): Promise<CMSArticle> {
+    const normalizedArticleId = String(articleId).trim();
+    const url = this.isNumericId(normalizedArticleId)
+      ? `${this.baseUrl}/api/archerbytes-articles/${encodeURIComponent(normalizedArticleId)}?depth=1`
+      : `${this.baseUrl}/api/archerbytes-articles?where[slug][equals]=${encodeURIComponent(normalizedArticleId)}&limit=1&depth=1`;
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!response.ok) {
+      throw new Error(`CMS API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as unknown;
+    const article = this.extractCMSData<CMSArticle>(data);
+    if (!article) {
+      throw new Error(`CMS article not found for identifier: ${normalizedArticleId}`);
+    }
+
+    return article;
+  }
+
+  async fetchCategory(categoryId: string | number): Promise<CMSCategory> {
+    const url = `${this.baseUrl}/api/archerbytes-article-category/${encodeURIComponent(String(categoryId).trim())}?depth=1`;
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!response.ok) {
+      throw new Error(`CMS API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as unknown;
+    const category = this.extractCMSData<CMSCategory>(data);
+    if (!category) {
+      throw new Error(`CMS category not found for identifier: ${String(categoryId).trim()}`);
+    }
+
+    return category;
+  }
+
+  private extractCMSData<T>(data: unknown): T {
+    if (data && typeof data === 'object' && 'data' in data) {
+      return (data as { data: T }).data;
+    }
+    if (data && typeof data === 'object' && 'doc' in data) {
+      return (data as { doc: T }).doc;
+    }
+    if (data && typeof data === 'object' && 'docs' in data) {
+      const docs = (data as { docs?: T[] }).docs;
+      return docs && docs.length > 0 ? docs[0] : (undefined as T);
+    }
+    return data as T;
+  }
+
+  private isNumericId(value: string): boolean {
+    return /^\d+$/.test(value);
+  }
+}
+
+export const cmsApiClient = new CMSApiClient();

--- a/src/lib/cms-api.ts
+++ b/src/lib/cms-api.ts
@@ -41,11 +41,21 @@ class CMSApiClient {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     }
-    const cmsApiToken = process.env.CMS_API_TOKEN
-    if (cmsApiToken) {
-      headers['Authorization'] = `Bearer ${cmsApiToken}`
+    const cmsApiKey = process.env.CMS_API_KEY
+    if (cmsApiKey) {
+      headers['Authorization'] = `users API-Key ${cmsApiKey}`
     }
     return headers
+  }
+
+  private normalizeArticle(article: CMSArticle): CMSArticle {
+    const { deleted_at, ...normalized } = article as CMSArticle & { deleted_at?: unknown }
+    return normalized as CMSArticle
+  }
+
+  private normalizeCategory(category: CMSCategory): CMSCategory {
+    const { deleted_at, ...normalized } = category as CMSCategory & { deleted_at?: unknown }
+    return normalized as CMSCategory
   }
 
   async fetchArticle(articleId: string | number): Promise<CMSArticle> {
@@ -70,7 +80,7 @@ class CMSApiClient {
       throw new Error(`CMS article not found for identifier: ${normalizedArticleId}`);
     }
 
-    return article;
+    return this.normalizeArticle(article);
   }
 
   async fetchCategory(categoryId: string | number): Promise<CMSCategory> {
@@ -92,7 +102,7 @@ class CMSApiClient {
       throw new Error(`CMS category not found for identifier: ${String(categoryId).trim()}`);
     }
 
-    return category;
+    return this.normalizeCategory(category);
   }
 
   private extractCMSData<T>(data: unknown): T {

--- a/src/lib/db/article-categories.entity.ts
+++ b/src/lib/db/article-categories.entity.ts
@@ -10,8 +10,10 @@ export const articleCategories = pgTable('article_categories', {
   description: text('description'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  deletedAt: timestamp('deleted_at'),
 }, (table) => [
   index('article_categories_cms_category_id_idx').on(table.cmsCategoryId),
+  index('article_categories_deleted_at_idx').on(table.deletedAt),
 ]);
 
 export const articleCategoriesRelations = relations(

--- a/src/lib/db/article-categories.entity.ts
+++ b/src/lib/db/article-categories.entity.ts
@@ -1,15 +1,18 @@
-import { pgTable, serial, varchar, text, timestamp } from 'drizzle-orm/pg-core';
+import { pgTable, serial, varchar, text, timestamp, integer, index } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 import { articles } from './article.entity';
 
 export const articleCategories = pgTable('article_categories', {
   id: serial('id').primaryKey(),
+  cmsCategoryId: integer('cms_category_id').unique(),
   name: varchar('name', { length: 255 }).notNull(),
   slug: varchar('slug', { length: 255 }).notNull().unique(),
   description: text('description'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
-});
+}, (table) => [
+  index('article_categories_cms_category_id_idx').on(table.cmsCategoryId),
+]);
 
 export const articleCategoriesRelations = relations(
   articleCategories,

--- a/src/lib/db/article.entity.ts
+++ b/src/lib/db/article.entity.ts
@@ -40,7 +40,6 @@ export const articles = pgTable(
     metaImageUrl: varchar('meta_image_url', { length: 1000 }),
     status: articleStatusEnum('status').notNull().default('draft'),
     publishedAt: timestamp('published_at'),
-    deletedAt: timestamp('deleted_at'),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },

--- a/src/lib/db/article.entity.ts
+++ b/src/lib/db/article.entity.ts
@@ -21,6 +21,7 @@ export const articles = pgTable(
   'articles',
   {
     id: serial('id').primaryKey(),
+    cmsArticleId: integer('cms_article_id').unique(),
     title: varchar('title', { length: 500 }).notNull(),
     subtitle: varchar('subtitle', { length: 500 }).notNull(),
     slug: varchar('slug', { length: 500 }).notNull().unique(),
@@ -42,8 +43,10 @@ export const articles = pgTable(
     publishedAt: timestamp('published_at'),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
+    deletedAt: timestamp('deleted_at'),
   },
   (table) => [
+    index('articles_cms_article_id_idx').on(table.cmsArticleId),
     index('articles_status_idx').on(table.status),
     index('articles_published_at_idx').on(table.publishedAt.desc()),
     index('articles_category_id_idx').on(table.categoryId),
@@ -51,6 +54,7 @@ export const articles = pgTable(
       table.status,
       table.publishedAt.desc(),
     ),
+    index('articles_deleted_at_idx').on(table.deletedAt),
   ],
 );
 

--- a/src/lib/db/article.entity.ts
+++ b/src/lib/db/article.entity.ts
@@ -40,6 +40,7 @@ export const articles = pgTable(
     metaImageUrl: varchar('meta_image_url', { length: 1000 }),
     status: articleStatusEnum('status').notNull().default('draft'),
     publishedAt: timestamp('published_at'),
+    deletedAt: timestamp('deleted_at'),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },

--- a/src/lib/webhooks/auth.ts
+++ b/src/lib/webhooks/auth.ts
@@ -1,0 +1,60 @@
+import { NextRequest } from 'next/server';
+
+export function extractBearerToken(req: NextRequest): string | undefined {
+  const authHeader = req.headers.get('Authorization');
+
+  if (!authHeader) {
+    return undefined;
+  }
+
+  const parts = authHeader.split(' ');
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    return undefined;
+  }
+
+  return parts[1];
+}
+export function verifyWebhookSecret(token: string): boolean {
+  const webhookSecret = process.env.WEBHOOK_SECRET;
+
+  if (!webhookSecret) {
+    console.error('WEBHOOK_SECRET environment variable is not configured');
+    return false;
+  }
+
+  return constantTimeCompare(token, webhookSecret);
+}
+
+
+function constantTimeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+
+  return result === 0;
+}
+
+export function validateWebhookAuth(req: NextRequest): { valid: boolean; error?: string } {
+  const token = extractBearerToken(req);
+
+  if (!token) {
+    return {
+      valid: false,
+      error: 'Missing or invalid Authorization header. Expected: Authorization: Bearer <token>',
+    };
+  }
+
+  if (!verifyWebhookSecret(token)) {
+    return {
+      valid: false,
+      error: 'Invalid webhook secret',
+    };
+  }
+
+  return { valid: true };
+}

--- a/src/lib/webhooks/handlers/article.handler.ts
+++ b/src/lib/webhooks/handlers/article.handler.ts
@@ -1,0 +1,17 @@
+import { type ArticleWebhookPayload } from '../types';
+import { CMSSyncService } from '@/features/article/services/cms-sync.service';
+
+export async function handleArticleEvent(payload: ArticleWebhookPayload): Promise<void> {
+  const { action, articleId } = payload as ArticleWebhookPayload & { articleId: string };
+
+  try {
+    if (action === 'created' || action === 'updated') {
+      await CMSSyncService.syncArticle(articleId);
+    } else if (action === 'deleted') {
+      await CMSSyncService.deleteArticle(articleId);
+    }
+  } catch (error) {
+    console.error(`[Webhook Handler] Failed to handle article:${action}:`, { articleId, error });
+    throw error;
+  }
+}

--- a/src/lib/webhooks/handlers/category.handler.ts
+++ b/src/lib/webhooks/handlers/category.handler.ts
@@ -1,0 +1,15 @@
+import { type CategoryWebhookPayload } from '../types';
+import { CMSSyncService } from '@/features/article/services/cms-sync.service';
+
+export async function handleCategoryEvent(payload: CategoryWebhookPayload): Promise<void> {
+  const { action, categoryId } = payload as CategoryWebhookPayload & { categoryId: string };
+
+  try {
+    if (action === 'created' || action === 'updated') {
+      await CMSSyncService.syncCategory(categoryId);
+    }
+  } catch (error) {
+    console.error(`[Webhook Handler] Failed to handle category:${action}:`, { categoryId, error });
+    throw error;
+  }
+}

--- a/src/lib/webhooks/handlers/category.handler.ts
+++ b/src/lib/webhooks/handlers/category.handler.ts
@@ -7,6 +7,8 @@ export async function handleCategoryEvent(payload: CategoryWebhookPayload): Prom
   try {
     if (action === 'created' || action === 'updated') {
       await CMSSyncService.syncCategory(categoryId);
+    } else if (action === 'deleted') {
+      await CMSSyncService.deleteCategory(categoryId);
     }
   } catch (error) {
     console.error(`[Webhook Handler] Failed to handle category:${action}:`, { categoryId, error });

--- a/src/lib/webhooks/response.ts
+++ b/src/lib/webhooks/response.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { WebhookResponse } from './types';
+
+function generateWebhookId(): string {
+  return `wh_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+}
+
+export function accepted(message: string = 'Webhook received and queued for processing'): NextResponse<WebhookResponse> {
+  const response: WebhookResponse = {
+    status: 'accepted',
+    message,
+    id: generateWebhookId(),
+    timestamp: new Date().toISOString(),
+  };
+
+  return NextResponse.json(response, { status: 202 });
+}
+
+export function badRequest(message: string, details?: unknown): NextResponse<WebhookResponse> {
+  const response: WebhookResponse = {
+    status: 'rejected',
+    message,
+    id: generateWebhookId(),
+    timestamp: new Date().toISOString(),
+    details,
+  };
+
+  return NextResponse.json(response, { status: 400 });
+}
+
+export function unauthorized(message: string = 'Unauthorized: Invalid webhook secret'): NextResponse<WebhookResponse> {
+  const response: WebhookResponse = {
+    status: 'rejected',
+    message,
+    id: generateWebhookId(),
+    timestamp: new Date().toISOString(),
+  };
+
+  return NextResponse.json(response, { status: 401 });
+}

--- a/src/lib/webhooks/types.ts
+++ b/src/lib/webhooks/types.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const ArticleWebhookPayloadSchema = z.object({
+  event: z.enum(['article.created', 'article.updated', 'article.deleted']),
+  articleId: z.string().min(1, 'articleId is required'),
+  timestamp: z.iso.datetime(),
+  cms: z.string().optional(),
+});
+
+export type ArticleWebhookPayload = z.infer<typeof ArticleWebhookPayloadSchema>;
+
+export const CategoryWebhookPayloadSchema = z.object({
+  event: z.enum(['category.created', 'category.updated', 'category.deleted']),
+  categoryId: z.string().min(1, 'categoryId is required'),
+  timestamp: z.iso.datetime(),
+  cms: z.string().optional(),
+});
+
+export type CategoryWebhookPayload = z.infer<typeof CategoryWebhookPayloadSchema>;
+
+export const WebhookPayloadSchema = z.discriminatedUnion('event', [
+  ArticleWebhookPayloadSchema,
+  CategoryWebhookPayloadSchema,
+]);
+
+export type WebhookPayload = z.infer<typeof WebhookPayloadSchema>;
+
+export interface WebhookResponse {
+  status: 'accepted' | 'rejected' | 'error';
+  message: string;
+  id: string;
+  timestamp: string;
+  details?: unknown;
+}

--- a/src/lib/webhooks/types.ts
+++ b/src/lib/webhooks/types.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 
 export const ArticleWebhookPayloadSchema = z.object({
-  event: z.enum(['article.created', 'article.updated', 'article.deleted']),
+  event: z.literal('article'),
+  action: z.enum(['created', 'updated', 'deleted']),
   articleId: z.string().min(1, 'articleId is required'),
   timestamp: z.iso.datetime(),
   cms: z.string().optional(),
@@ -10,7 +11,8 @@ export const ArticleWebhookPayloadSchema = z.object({
 export type ArticleWebhookPayload = z.infer<typeof ArticleWebhookPayloadSchema>;
 
 export const CategoryWebhookPayloadSchema = z.object({
-  event: z.enum(['category.created', 'category.updated', 'category.deleted']),
+  event: z.literal('category'),
+  action: z.enum(['created', 'updated', 'deleted']),
   categoryId: z.string().min(1, 'categoryId is required'),
   timestamp: z.iso.datetime(),
   cms: z.string().optional(),


### PR DESCRIPTION
### Summary

This pr implements a secure webhook receiver in Archerbytes that listens for CMS publish/create events and syncs articles and categories into the local database. 

### Linked Issues

closes \#29

### Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] chore/refactor: Maintenance or code restructure

### Notes for Reviewers

- uses Bearer Token Auth
- Idempotent Upsert: Articles/categories keyed by slug with ON CONFLICT DO UPDATE to ensure no duplicates on CMS retries
- Soft Deletes: Deleted articles set deleted_at timestamp instead of hard delete

- All synced articles assigned to SYSTEM_USER_ID (must be configured in .env.)
